### PR TITLE
node: use centos7-s2i-nodejs as the base image

### DIFF
--- a/hello/nodejs/Dockerfile
+++ b/hello/nodejs/Dockerfile
@@ -1,12 +1,12 @@
-FROM node:8
+FROM bucharestgold/centos7-s2i-nodejs:10.x
 
-MAINTAINER Burr Sutter "burrsutter@gmail.com"
+LABEL maintainer="Burr Sutter \"burrsutter@gmail.com\""
 
 EXPOSE 8000
 
-WORKDIR /usr/src/
+WORKDIR /opt/app-root/src
 
-COPY hello-http.js /usr/src
-COPY package.json /usr/src
+COPY hello-http.js .
+COPY package.json .
 
-CMD ["/bin/bash", "-c", "npm start" ]
+CMD ["npm", "start"]

--- a/hello/nodejs/hello-http.js
+++ b/hello/nodejs/hello-http.js
@@ -1,10 +1,10 @@
-var http = require('http');
-var cnt = 0;
+const os = require('os');
+const http = require('http');
+let cnt = 0;
 
-http.createServer(function (req, res) {
-    var now = new Date();
-    res.end('Bonjour from Node.js! ' + cnt++ + ' on ' + process.env.HOSTNAME  + '\n');
-    
-}).listen(8000, '0.0.0.0');
-console.log('Server running at http://:8000/');
+http.createServer((req, res) =>
+    res.end(`Bonjour from Node.js! ${cnt++} on ${os.hostname()}\n`)
+).listen(8000);
+
+console.log(`Server running at http://localhost:8000/`);
 


### PR DESCRIPTION
Instead of using node:8 as the base image, let's use
Red Hat's own centos7-s2i-nodejs. This image can be used
to build application containers using either `docker build`
or the S2I process. It is also about 100MB smaller than the
official node:10 image.

In addition to this change, I have cleaned up the javascript
to adhere more closely to conventions for 10.x applications,
and the Dockerfile to use `LABEL` instead of `MAINTAINER`
which is deprecated.