### PR TITLE
Update 1_installation_started.adoc

### DIFF
--- a/1_installation_started.adoc
+++ b/1_installation_started.adoc
@@ -35,7 +35,7 @@ $ curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin
 # 
 $ chmod +x kubectl
 # or
-$ brew install kubectl 
+$ brew install kubernetes-cli
 ----
 Linux & Windows instructions for finding and downloading the a kubectl 
 https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl


### PR DESCRIPTION
There is no `kubectl` brew package, according to documentation the package is called `kubernetes-cli`. Source: https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-with-homebrew-on-macos