### PR TITLE
Nodeshift name change and minor doc change

### DIFF
--- a/hello/nodejs/Dockerfile
+++ b/hello/nodejs/Dockerfile
@@ -1,4 +1,4 @@
-FROM bucharestgold/centos7-s2i-nodejs:10.x
+FROM nodeshift/centos7-s2i-nodejs:10.x
 
 LABEL maintainer="Burr Sutter \"burrsutter@gmail.com\""
 

--- a/hello/nodejs/readme.txt
+++ b/hello/nodejs/readme.txt
@@ -12,7 +12,7 @@ Test it in Docker
 minishift docker-env
 minikube docker-env
 
-docker build -t 9stepsawesome/mynode:v1 . 
+docker build -t 9stepsawesome/mynode:v1 .
 
 docker images | grep mynode
 

--- a/hello/nodejs/readme.txt
+++ b/hello/nodejs/readme.txt
@@ -16,13 +16,11 @@ docker build -t 9stepsawesome/mynode:v1 .
 
 docker images | grep mynode
 
-docker run -d -p 8000:8000 9stepsawesome/mynode:v1
+docker run --rm -d -p 8000:8000 9stepsawesome/mynode:v1
 
 docker ps | grep mynode
 
 docker stop 08efa083696b
-
-docker rm 08efa083696b
 
 deploy it into minikube/minishift
 kubectl create -f kubefiles/mynode-deployment.yml


### PR DESCRIPTION
This PR changes the repository name for the node.js dockerfile to `nodeshift` following the upstream name change. It also includes a minor simplification to the documentation around testing the node app with Docker.