### PR TITLE
Add help about darwin/linux

### DIFF
--- a/0_quickstart.adoc
+++ b/0_quickstart.adoc
@@ -25,6 +25,9 @@ cd bin
 ----
 
 === Download minikube & kubectl
+
+Some lines are Mac OS based, but if you are on Linux, change `darwin` to `linux`.
+
 ----
 curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.4.0/minikube-darwin-amd64
 

--- a/1_installation_started.adoc
+++ b/1_installation_started.adoc
@@ -12,7 +12,7 @@ OpenShift is Red Hat's distribution of Kubernetes
 
 minikube and minishift are essentially equivalent and will be used for the demonstrations/examples below.
 
-These instructions are primarily for Linux & MacOS.  At some point, I do hope to find the time translate them to Windows PowerShell.  
+These instructions are primarily for Linux & MacOS.  At some point, I do hope to find the time translate them to Windows PowerShell. If you are on Linux, for the lines containing `darwin`, change `darwin` to `linux`.
 These instructions have NOT been tested well on Windows Bash.
 
 === Prerequisites


### PR DESCRIPTION
There is nothing saying in the docs right now, that it is mac specific.
If a linux user tries to use the darwin version, they will get a confusing `exec format error`.