### PR TITLE
fix incorrect brew command for installing minikube

### DIFF
--- a/1_installation_started.adoc
+++ b/1_installation_started.adoc
@@ -51,7 +51,7 @@ Download & Install Minikube Cluster
 $ curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.4.0/minikube-darwin-amd64
 $ chmod +x minikube 
 # or
-$ brew cask install minikube
+$ brew install minikube
 # if you don't have VirtualBox installed
 $ brew cask install virtualbox
 ----


### PR DESCRIPTION
Hey,
No Cask with name "minikube" exists.